### PR TITLE
Fix Bottom Bar Problem

### DIFF
--- a/android/app/src/main/java/org/uwaterloo/subletr/navigation/MainNavigation.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/navigation/MainNavigation.kt
@@ -24,13 +24,13 @@ fun MainNavigation(
 	modifier: Modifier = Modifier,
 	navHostController: NavHostController = rememberNavController(),
 ) {
-	val startingDestination =
-		if (ApiClient.accessToken == null) NavigationDestination.LOGIN.fullNavPath
-		else NavigationDestination.HOME.fullNavPath
+	val startingDestination: NavigationDestination =
+		if (ApiClient.accessToken == null) NavigationDestination.LOGIN
+		else NavigationDestination.HOME
 
 	NavHost(
 		navController = navHostController,
-		startDestination = startingDestination,
+		startDestination = startingDestination.fullNavPath,
 	) {
 		composable(NavigationDestination.LOGIN.fullNavPath) {
 			LoginPageView(

--- a/android/app/src/main/java/org/uwaterloo/subletr/pages/home/HomePageView.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/pages/home/HomePageView.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,9 +33,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.navOptions
 import org.uwaterloo.subletr.R
 import org.uwaterloo.subletr.enums.Gender
 import org.uwaterloo.subletr.enums.HousingType
+import org.uwaterloo.subletr.navigation.NavigationDestination
 import org.uwaterloo.subletr.pages.home.list.HomeListChildView
 import org.uwaterloo.subletr.pages.home.list.HomeListUiState
 import org.uwaterloo.subletr.pages.home.map.HomeMapChildView
@@ -72,21 +75,39 @@ fun HomePageView(
 					text = stringResource(id = R.string.view_sublets),
 					style = MaterialTheme.typography.titleMedium,
 				)
-				ViewSwitch(isListView = isListView, viewModel = viewModel)
+				ViewSwitch(isListView = isListView)
 			}
 		},
 		content = { padding: PaddingValues ->
-			if (uiState is HomeListUiState) {
-				HomeListChildView(
-					modifier = Modifier.padding(padding),
-					viewModel = viewModel.homeListChildViewModel,
-					uiState = uiState,
-				)
-			} else if (uiState is HomeMapUiState) {
-				HomeMapChildView(
-					modifier = Modifier.padding(padding),
-					viewModel = viewModel.homeMapChildViewModel,
-				)
+			when (uiState) {
+				is HomeListUiState.Failed -> {
+					LaunchedEffect(key1 = true) {
+						viewModel.navHostController.navigate(
+							route = NavigationDestination.LOGIN.rootNavPath,
+							navOptions = navOptions {
+								popUpTo(viewModel.navHostController.graph.id) {
+									saveState = true
+								}
+								launchSingleTop = true
+							},
+						)
+					}
+				}
+
+				is HomeListUiState -> {
+					HomeListChildView(
+						modifier = Modifier.padding(padding),
+						viewModel = viewModel.homeListChildViewModel,
+						uiState = uiState,
+					)
+				}
+
+				is HomeMapUiState -> {
+					HomeMapChildView(
+						modifier = Modifier.padding(padding),
+						viewModel = viewModel.homeMapChildViewModel,
+					)
+				}
 			}
 		},
 		bottomBar = {
@@ -99,7 +120,6 @@ fun HomePageView(
 fun ViewSwitch(
 	modifier: Modifier = Modifier,
 	isListView: MutableState<Boolean>,
-	viewModel: HomePageViewModel,
 ) {
 	Row(
 		modifier = modifier

--- a/android/app/src/main/java/org/uwaterloo/subletr/pages/home/list/HomeListUiState.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/pages/home/list/HomeListUiState.kt
@@ -6,8 +6,6 @@ import org.uwaterloo.subletr.api.models.ListingSummary
 import org.uwaterloo.subletr.enums.Gender
 import org.uwaterloo.subletr.enums.HousingType
 import org.uwaterloo.subletr.pages.home.HomePageUiState
-import java.util.Optional
-import java.util.prefs.AbstractPreferences
 
 sealed interface HomeListUiState: HomePageUiState {
 	object Loading : HomeListUiState
@@ -44,4 +42,6 @@ sealed interface HomeListUiState: HomePageUiState {
 		val houseTypePreference: HousingType,
 		@StringRes val infoTextStringId: Int?,
 	) : HomeListUiState
+
+	object Failed : HomeListUiState
 }

--- a/android/app/src/main/java/org/uwaterloo/subletr/pages/login/LoginPageViewModel.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/pages/login/LoginPageViewModel.kt
@@ -59,7 +59,7 @@ class LoginPageViewModel @Inject constructor(
 			}
 				.onSuccess {
 					authenticationService.setAccessToken(it.token)
-					navHostController.navigate(NavigationDestination.HOME.rootNavPath)
+					navHostController.navigate(NavigationDestination.HOME.fullNavPath)
 				}
 				.onFailure {
 					infoTextStringIdStream.onNext(

--- a/android/app/src/main/java/org/uwaterloo/subletr/scaffold/MainScaffoldView.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/scaffold/MainScaffoldView.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.currentBackStackEntryAsState
+import org.uwaterloo.subletr.api.infrastructure.ApiClient
 import org.uwaterloo.subletr.components.bottombar.BottomBarView
 import org.uwaterloo.subletr.navigation.MainNavigation
 import org.uwaterloo.subletr.navigation.NavigationDestination
@@ -21,7 +22,9 @@ fun MainScaffoldView(
 	viewModel: MainScaffoldViewModel = hiltViewModel(),
 ) {
 	val snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
-	var currentDestination: NavigationDestination = NavigationDestination.LOGIN
+	var currentDestination: NavigationDestination =
+		if (ApiClient.accessToken == null) NavigationDestination.LOGIN
+		else NavigationDestination.HOME
 
 	NavigationDestination.values().forEach {
 		if (

--- a/android/app/src/main/java/org/uwaterloo/subletr/services/INotificationService.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/services/INotificationService.kt
@@ -1,4 +1,3 @@
 package org.uwaterloo.subletr.services
 
-interface INotificationService {
-}
+interface INotificationService


### PR DESCRIPTION
To explain the issue, the problem essentially happens because `viewModels` are loaded lazily and before `views`, which are also loaded lazily.
The bottom bar relies on Compose's internal change events but the navigation for pages just uses plain old state.
Since the event for navigating to login ends before the event for navigating to home (since navigating to home fails due to errors on the home page), the bottom bar thinks that we're on the home page but the navigation knows that we're on the login page. 