### PR TITLE
use view model scope for location requests

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 	implementation 'androidx.core:core-ktx:1.10.1'
 	implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
 	implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+	implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
 	implementation 'androidx.navigation:navigation-runtime:2.6.0'
 	implementation 'androidx.navigation:navigation-compose:2.6.0'
 	implementation platform('androidx.compose:compose-bom:2022.10.00')

--- a/android/app/src/main/java/org/uwaterloo/subletr/pages/home/HomePageViewModel.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/pages/home/HomePageViewModel.kt
@@ -1,11 +1,14 @@
 package org.uwaterloo.subletr.pages.home
 
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.reactivex.rxjava3.core.Observable
+import kotlinx.coroutines.launch
 import org.uwaterloo.subletr.infrastructure.SubletrViewModel
 import org.uwaterloo.subletr.pages.home.list.HomeListChildViewModel
 import org.uwaterloo.subletr.pages.home.map.HomeMapChildViewModel
+import org.uwaterloo.subletr.services.ILocationService
 import org.uwaterloo.subletr.services.INavigationService
 import javax.inject.Inject
 
@@ -14,6 +17,7 @@ class HomePageViewModel @Inject constructor(
 	private val navigationService: INavigationService,
 	val homeListChildViewModel: HomeListChildViewModel,
 	val homeMapChildViewModel: HomeMapChildViewModel,
+	private val locationService: ILocationService,
 ) : SubletrViewModel<HomePageUiState>(
 	homeListChildViewModel,
 	homeMapChildViewModel,
@@ -22,5 +26,12 @@ class HomePageViewModel @Inject constructor(
 
 	override val uiStateStream: Observable<HomePageUiState> = homeListChildViewModel.uiStateStream.map {
 		it
+	}
+
+	init {
+		viewModelScope.launch {
+			val loc = locationService.getLocation()
+			println(loc.toString())
+		}
 	}
 }


### PR DESCRIPTION
Some stuff I found

- To use `locationService.getLocation()`, it must be inside either `viewModelScope.launch {` or `lifecycleScope.launch {`
- Location permissions for the app must be enabled (obviously)
  - when does the "ask for location permission" modal pop up?
- `SubletrChildViewModel` doesn't implement `ViewModel`, is that intended?