### PR TITLE
Fixing the listing view crashing

### DIFF
--- a/android/app/src/main/java/org/uwaterloo/subletr/pages/home/list/HomeListChildView.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/pages/home/list/HomeListChildView.kt
@@ -317,7 +317,7 @@ fun HomeListChildView(
 
 				items(uiState.listingItems.listings.size) {
 					val listingSummary = uiState.listingItems.listings[it]
-					val listingImage = uiState.listingItems.listingsImages[it]
+					val listingImage = if (uiState.listingItems.listingsImages.size > it ) uiState.listingItems.listingsImages[it] else null
 					ListingPost(
 						listingSummary = listingSummary,
 						listingImage = listingImage,
@@ -330,7 +330,6 @@ fun HomeListChildView(
 				}
 			}
 		}
-
 	}
 }
 


### PR DESCRIPTION
The img api call returns slower than the listing summary call, in the case that the listing image array is smaller than the listing summary array, the app crashes.... using a default image to prevent crashing. 