### PR TITLE
Round listing latitude / longitude

### DIFF
--- a/server/src/api/constants.rs
+++ b/server/src/api/constants.rs
@@ -1,3 +1,5 @@
 pub const JWT_SECRET: &'static str = "test"; // std::env!("API_SECRET_KEY");
 pub const JWT_AUDIENCE: &'static str = "server_cs458";
 pub const JWT_EXP_HOURS: i64 = 1;
+
+pub const GEOCODE_MAX_DECIMALS: u32 = 4;

--- a/server/src/api/geocode/mod.rs
+++ b/server/src/api/geocode/mod.rs
@@ -5,6 +5,7 @@ use rocket_okapi::{openapi, openapi_get_routes_spec};
 use tokio::sync::RwLockWriteGuard;
 
 use super::{
+    constants::GEOCODE_MAX_DECIMALS,
     model::geocode::{ForwardGeocodeRequest, ForwardGeocodeResponse},
     token::AuthenticatedUser,
     utils::format_address,
@@ -22,9 +23,11 @@ pub async fn geocode_address(
     let response: Vec<Point> = opencage.forward(&address).await?;
 
     if let Some(point) = response.first() {
+        let round = 10i32.pow(GEOCODE_MAX_DECIMALS) as f32;
+
         Ok(ForwardGeocodeResponse {
-            latitude: point.0.y as f32,
-            longitude: point.0.x as f32,
+            latitude: (point.0.y as f32 * round).round() / round,
+            longitude: (point.0.x as f32 * round).round() / round,
         })
     } else {
         Err(ServiceError::GeocodingError(GeocodingError::Forward))

--- a/server/src/api/listings/mod.rs
+++ b/server/src/api/listings/mod.rs
@@ -46,7 +46,7 @@ use crate::{
 async fn listings_create(
     state: &State<AppState<'_>>,
     user: AuthenticatedUser,
-    listing_request: Json<CreateListingRequest>,
+    mut listing_request: Json<CreateListingRequest>,
 ) -> ServiceResult<CreateListingResponse> {
     let mut dbcon = state.pool.get()?;
 
@@ -61,6 +61,11 @@ async fn listings_create(
     let listing_id: i32 = rand::thread_rng().gen();
 
     let opencage = state.opencage.write().await;
+
+    listing_request.address_line = listing_request.address_line.trim().to_owned();
+    listing_request.address_city = listing_request.address_city.trim().to_owned();
+    listing_request.address_postalcode = listing_request.address_postalcode.trim().to_owned();
+    listing_request.address_country = listing_request.address_country.trim().to_owned();
 
     let location = geocode_address(
         opencage,


### PR DESCRIPTION
Idea for sublet location privacy
- less precision on latitude and longitude so the maps isn't pinpoint perfect
- take out numbers in address line when displaying

I have no idea if other things will break because of these changes
I also have no idea what I'm doing