### PR TITLE
Have individual inputs for address components when creating listng

### DIFF
--- a/android/app/src/main/java/org/uwaterloo/subletr/components/addressautocomplete/AddressAutocomplete.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/components/addressautocomplete/AddressAutocomplete.kt
@@ -21,7 +21,6 @@ import com.google.android.libraries.places.api.model.AutocompletePrediction
 import org.uwaterloo.subletr.R
 import org.uwaterloo.subletr.components.textfield.RoundedTextField
 import org.uwaterloo.subletr.theme.subletrPalette
-import org.uwaterloo.subletr.utils.addressStringIsEmpty
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,6 +30,7 @@ fun AddressAutocomplete(
 	addressAutocompleteOptions: ArrayList<AutocompletePrediction>,
 	setAddress: (String) -> Unit,
 	attemptingCreate: Boolean = false,
+	onPredictionSelection: () -> Unit = {},
 ) {
 	var autocompleteExpanded by remember { mutableStateOf(false) }
 	val focusManager = LocalFocusManager.current
@@ -47,7 +47,7 @@ fun AddressAutocomplete(
 				.border(
 					width = dimensionResource(id = R.dimen.xxxs),
 					color =
-					if (!attemptingCreate || !addressStringIsEmpty(fullAddress))
+					if (!attemptingCreate || fullAddress.isNotBlank())
 						MaterialTheme.subletrPalette.textFieldBorderColor
 					else
 						MaterialTheme.subletrPalette.warningColor,
@@ -63,7 +63,7 @@ fun AddressAutocomplete(
 				Text(
 					text = stringResource(id = R.string.address),
 					color =
-						if (!attemptingCreate || !addressStringIsEmpty(fullAddress))
+						if (!attemptingCreate || fullAddress.isNotBlank())
 							MaterialTheme.subletrPalette.secondaryTextColor
 						else
 							MaterialTheme.subletrPalette.warningColor,
@@ -86,8 +86,9 @@ fun AddressAutocomplete(
 					text = { Text(text = prediction.getFullText(null).toString()) },
 					onClick = {
 						setAddress(prediction.getFullText(null).toString())
-						focusManager.clearFocus()
 						autocompleteExpanded = false
+						focusManager.clearFocus()
+						onPredictionSelection()
 					},
 				)
 			}

--- a/android/app/src/main/java/org/uwaterloo/subletr/components/textfield/RoundedTextField.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/components/textfield/RoundedTextField.kt
@@ -53,6 +53,7 @@ fun RoundedTextField(
 		focusedContainerColor = MaterialTheme.subletrPalette.textFieldBackgroundColor,
 		unfocusedIndicatorColor = Color.Transparent,
 		focusedIndicatorColor = Color.Transparent,
+		disabledIndicatorColor = Color.Transparent,
 	),
 ) {
 	TextField(

--- a/android/app/src/main/java/org/uwaterloo/subletr/pages/createlisting/CreateListingPageUiState.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/pages/createlisting/CreateListingPageUiState.kt
@@ -2,9 +2,10 @@ package org.uwaterloo.subletr.pages.createlisting
 
 import android.graphics.Bitmap
 import com.google.android.libraries.places.api.model.AutocompletePrediction
+import org.uwaterloo.subletr.R
 import org.uwaterloo.subletr.enums.EnsuiteBathroomOption
-import org.uwaterloo.subletr.enums.ListingForGenderOption
 import org.uwaterloo.subletr.enums.HousingType
+import org.uwaterloo.subletr.enums.ListingForGenderOption
 
 sealed interface CreateListingPageUiState {
 	object Loading : CreateListingPageUiState
@@ -20,6 +21,7 @@ sealed interface CreateListingPageUiState {
 	data class Loaded(
 		val address: AddressModel,
 		val addressAutocompleteOptions: ArrayList<AutocompletePrediction>,
+		val isAutocompleting: Boolean,
 		val description: String,
 		val price: Int,
 		val numBedrooms: Int,
@@ -36,4 +38,11 @@ sealed interface CreateListingPageUiState {
 		val imagesBitmap: MutableList<Bitmap?>,
 		val images: List<String>,
 	) : CreateListingPageUiState
+
+	fun AddressModel.getInfoDisplay(): List<Pair<Int, String>> = listOf(
+		Pair(R.string.address_line, addressLine),
+		Pair(R.string.city, addressCity),
+		Pair(R.string.postal_code, addressPostalCode),
+		Pair(R.string.country, addressCountry),
+	)
 }

--- a/android/app/src/main/java/org/uwaterloo/subletr/pages/listingdetails/ListingDetailsPageUiState.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/pages/listingdetails/ListingDetailsPageUiState.kt
@@ -60,5 +60,6 @@ sealed interface ListingDetailsPageUiState {
 		Pair(R.string.bathrooms, bathroomsAvailable),
 		Pair(R.string.ensuite_bathroom, if (bathroomsEnsuite > 0) R.string.yes else R.string.no),
 		Pair(R.string.total_bathrooms_in_house, bathroomsTotal),
+		Pair(R.string.housing_type, residenceType),
 	)
 }

--- a/android/app/src/main/java/org/uwaterloo/subletr/utils/CreatingListingUtils.kt
+++ b/android/app/src/main/java/org/uwaterloo/subletr/utils/CreatingListingUtils.kt
@@ -20,4 +20,9 @@ fun addressIsEmpty(addressModel: CreateListingPageUiState.AddressModel): Boolean
 		addressModel.fullAddress == ""
 }
 
-fun addressStringIsEmpty(fullAddress: String): Boolean = fullAddress == ""
+fun addressHasEmpty(addressModel: CreateListingPageUiState.AddressModel): Boolean {
+	return addressModel.addressCity.isBlank() ||
+		addressModel.addressLine.isBlank() ||
+		addressModel.addressPostalCode.isBlank() ||
+		addressModel.fullAddress.isBlank()
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -216,4 +216,8 @@
     <string name="updated_listing">Updated listing</string>
     <string name="delete_listing">Delete listing</string>
     <string name="delete_listing_dialog">Are you sure you want to delete your listing? This action can not be undone.</string>
+    <string name="address_line">Address line</string>
+    <string name="city">City</string>
+    <string name="postal_code">Postal code</string>
+    <string name="country">Country</string>
 </resources>


### PR DESCRIPTION
Did some manual testing, not in a sophisticated "I want to find bugs" way but more of an honest user way that may encounter issues

After selecting an address prediction, individual text fields appear for each address component that will need values for a listing to be created

If at any point the user wants to autocomplete again, the user can type into the top autocomplete text field to find predictions and the individual address component text fields will disappear

- If the user does not select an address prediction and straight up manually inputs everything then taps `Create Post`,
  - if it's a well formatted input that the backend accepts, the listing is created without issues
  - if postal code (or any other address field) is causing issues, the individual text field inputs will appear and have warning colours